### PR TITLE
cimgはentrypoint.shに不具合があるためcimgの使用をやめる

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -1,8 +1,8 @@
-FROM cimg/postgres:12.11
+FROM postgres:12.11
 LABEL maintainer="dev@icare.jpn.com"
 RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
 ENV LANG=ja_JP.utf8
-RUN echo -e "\n\
+RUN echo "\n\
 #listen_addresses = '*'\n\
 max_connections = 100\n\
 shared_buffers = 160MB\n\
@@ -32,4 +32,4 @@ timezone = 'Asia/Tokyo'\n\
 #lc_numeric = 'ja_JP.utf8'\n\
 #lc_time = 'ja_JP.utf8'\n\
 #default_text_search_config = 'pg_catalog.simple'\n\
-" >>/usr/lib/postgresql/12/share/postgresql.conf.sample
+" >>/usr/share/postgresql/12/postgresql.conf.sample


### PR DESCRIPTION
cimgはentrypoint.shに不具合がありPGDATAディレクトリの移動ができないためcimgの使用をやめる
CircleCIのテストでは特に問題はない
この変更により「開発環境」のDBと「CIテスト用」のDBの設定値はfsync周りの違いしかなくなった