### PR TITLE
pg_bigm（全文検索機能を提供するモジュール）をインストール

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -y \
   && cd pg_bigm-1.2-20200228 \
   && make USE_PGXS=1 \
   && make USE_PGXS=1 install \
-  && rm -rf pg_bigm-1.2-20200228 pg_bigm-1.2-20200228.tar.gz
+  && rm -rf /pg_bigm-1.2-20200228 /pg_bigm-1.2-20200228.tar.gz
 RUN echo "\n\
 #listen_addresses = '*'\n\
 max_connections = 100\n\

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -y \
   && cd pg_bigm-1.2-20200228 \
   && make USE_PGXS=1 \
   && make USE_PGXS=1 install \
-  && rm -rf pg_bigm-1.2-20200228 pg_bigm-1.2-20200228.tar.gz
+  && rm -rf /pg_bigm-1.2-20200228 /pg_bigm-1.2-20200228.tar.gz
 RUN echo "\n\
 #listen_addresses = '*'\n\
 max_connections = 100\n\


### PR DESCRIPTION
# 概要

全文検索用のインデックスを使用するためpg_bigmをインストールするようにしました。
参考: https://pgbigm.osdn.jp/pg_bigm-1-2.html

# 動作確認

wwwのdbイメージを書き換え、動作確認。
コンテナ立ち上げ後、PostgreSQLにログインして以下を実行。

```sql
carely_development=# CREATE EXTENSION pg_bigm;
CREATE EXTENSION

carely_development=# SELECT * FROM pg_extension;
   oid   |  extname  | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition
---------+-----------+----------+--------------+----------------+------------+-----------+--------------
   13396 | plpgsql   |       10 |           11 | f              | 1.0        |           |
 1373475 | uuid-ossp |       10 |         2200 | t              | 1.1        |           |
 1374335 | intarray  |       10 |         2200 | t              | 1.2        |           |
 1381441 | pg_bigm   |       10 |         2200 | t              | 1.2        |           |
(4 行)
```