### PR TITLE
PostgreSQLのバージョンを14.16に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.11
+FROM postgres:14.16
 LABEL maintainer="dev@icare.jpn.com"
 
 ENV LANG=ja_JP.utf8

--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@
 ## Docker Image
 
 [docker hub](https://hub.docker.com/r/icarejposs/postgres-ja-jp-utf8)でイメージをホストしています。
+
+## docker hubでイメージをホストする仕組み
+
+- Automated buildsの機能でgit pushに反応してホストされる
+- PostgreSQLのバージョンアップ時などは下記対応を行う
+    - DockerfileのFROMを更新
+    - PRを作成
+    - docker hub上でイメージがビルドされることを確認
+    - 該当のブランチに対してタグをpush
+    - 例
+
+    ```
+    git tag -a **.**(version) -m "image with Postgres version **.**"
+    git push origin --tags <branche-name>
+    ```
+    - docker hub上でイメージがビルドされることを確認 

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/postgres:14.11
+FROM arm64v8/postgres:14.16
 LABEL maintainer="dev@icare.jpn.com"
 
 ENV LANG=ja_JP.utf8

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.11
+FROM postgres:14.16
 LABEL maintainer="dev@icare.jpn.com"
 
 ENV LANG=ja_JP.utf8


### PR DESCRIPTION
## 概要

- PostgreSQLのバージョンを14.11から14.16に変更する
- またREADMEでdockerhubへのアップロード方法を記載

### 変更箇所

- https://github.com/icare-jp-oss/postgres-ja-jp-utf8/pull/14/commits/1b592ac15059ed4c50033860781ed25343e6febd
    - バージョンを14.16に変更
- https://github.com/icare-jp-oss/postgres-ja-jp-utf8/pull/14/commits/f0081490a492114d7572f38fe3ab3daed0384070
    - READMEを更新

### 動作確認方法/ポイント

- DockerHubに14.16バージョンでイメージがビルドしていることを確認(armを除く)
    - https://hub.docker.com/r/icarejposs/postgres-ja-jp-utf8/tags
- アップロードが成功したイメージで開発環境が動作することを確認
